### PR TITLE
Properly decode lists with the integer 0

### DIFF
--- a/bencode.js
+++ b/bencode.js
@@ -280,7 +280,7 @@ var Bdecode = function () {
         if (LIST_START === obj) {
           var obj2 = null
           var list = []
-          while( obj2 = tmp_stack.pop() ) {
+          while( undefined !== (obj2 = tmp_stack.pop()) ) {
             list.push(obj2)
           }
           self.cb(list)

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 
-var benc = require('../bencode.js'),
-    hexy = require('hexy')
+var benc = require('../bencode.js');
 
 
 function log(msg) {
@@ -305,6 +304,12 @@ function file_bug() {
   })
 }
 
+function list_0() {
+  var data = 'li0ee';
+  var decoded = benc.decode(data);
+  assert_obj("List with 0", [0], decoded);
+}
+
 docs()
 str_e()
 num_e()
@@ -317,6 +322,7 @@ list_d()
 errors()
 file()
 file_bug()
+list_0()
 //file_readStream("test/bloeh.torrent");
 //console.log("here")
 file_readStream("test/chipcheezum.torrent");


### PR DESCRIPTION
Without checking if the `pop()` variable is undefined, any integers that are 0 on the list will not be there on the decoded object. I'm guessing the same goes for empty strings because Javascript considers them "false" too.

``` js
  var data = 'li0ee';
  var decoded = benc.decode(data);
  assert_obj("List with 0", [0], decoded);
```
