### PR TITLE
Global leaks (buf, buf2)

### DIFF
--- a/bencode.js
+++ b/bencode.js
@@ -406,8 +406,8 @@ var Bencode = function(obj) {
   }
 
   function encodeBuffer(obj) {
-    var len = obj.length.toString(10)
-        buf = new Buffer(len.length+1+obj.length)
+    var len = obj.length.toString(10),
+        buf = new Buffer(len.length+1+obj.length);
 
     buf.write(len, 0, "ascii")
     buf.write(":", len.length, "ascii")
@@ -437,7 +437,7 @@ var Bencode = function(obj) {
       if (buffer.length > num+pos+1) {
         return
       } else {
-        buf2 = new Buffer(buffer.length + num) 
+        var buf2 = new Buffer(buffer.length + num) 
         buffer.copy(buf2, 0, 0)
         buffer = buf2
       }


### PR DESCRIPTION
Hey, great library.

One small issue: global leaks. I use mocha as my testsuite, which detects global leaks by default. It noticed that bencode.js leaks `buf` and `buf2`. `buf` is leaked due to automatic semicolon insertion, while `buf2` is just missing a `var`. I've attached a pull request that I've tested.

Thanks!
