### PR TITLE
Added a function current_result which allows reading partial buffers

### DIFF
--- a/bencode.js
+++ b/bencode.js
@@ -325,6 +325,10 @@ var Bdecode = function () {
     }
     return ctx.result()
   }
+  
+  this.current_result    = function () {
+    return ctx.result()
+  }
 
   this.decode = function(buf, encoding) {
     smachine.parse(buf, encoding)


### PR DESCRIPTION
Sometimes we have to parse buffers progressively. It helps to have access to what's already processed.
