### PR TITLE
Remove bops. browserify's buffer works better now!

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,5 @@
     "test": "node test/test.js"
   },
   "dependencies": {
-    "bops": "~0.1.0"
   }
 }


### PR DESCRIPTION
Browserify now uses native-buffer-browserify
(https://github.com/feross/native-buffer-browserify), a browser Buffer
implementation that is backed by Uint8Array so it’s fast. And we get
to keep the node API that we’re familiar with. Best of both worlds!
